### PR TITLE
before_render_post event to add uuid if post not has uuid

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,4 +2,6 @@
 
 const HexoUuid = require('./lib/hexo-uuid');
 
-hexo.on('new', HexoUuid);
+hexo.on('new', HexoUuid.newPost);
+
+hexo.extend.filter.register('before_post_render', HexoUuid.before_renderPost);

--- a/lib/hexo-uuid.js
+++ b/lib/hexo-uuid.js
@@ -3,7 +3,7 @@
 const uuid = require('uuid');
 const fs = require('fs');
 
-module.exports = (post) => {
+module.exports.newPost = (post) => {
 
   let lines = post.content.split('\n');
   let index = lines.findIndex(item => item === 'uuid:');
@@ -18,4 +18,19 @@ module.exports = (post) => {
     fs.writeFile(post.path, post.content);
   }
 
+};
+
+module.exports.before_renderPost = (post) => {
+  if (post.layout == 'post' && (!post.uuid || post.uuid == '')) {
+    let lines = post.raw.split('\n');
+    let index = lines.findIndex(item => item === 'uuid:');
+    if (index > -1) {
+      lines[index] += (' ' + uuid.v1());
+    } else {
+      lines.splice(1, 0, 'uuid: ' + uuid.v1());
+    }
+
+    post.raw = lines.join('\n');
+    fs.writeFile(post.full_source, post.raw);
+  }
 };

--- a/lib/hexo-uuid.js
+++ b/lib/hexo-uuid.js
@@ -24,10 +24,11 @@ module.exports.before_renderPost = (post) => {
   if (post.layout == 'post' && (!post.uuid || post.uuid == '')) {
     let lines = post.raw.split('\n');
     let index = lines.findIndex(item => item === 'uuid:');
+    post.uuid = uuid.v1();
     if (index > -1) {
-      lines[index] += (' ' + uuid.v1());
+      lines[index] += (' ' + post.uuid);
     } else {
-      lines.splice(1, 0, 'uuid: ' + uuid.v1());
+      lines.splice(1, 0, 'uuid: ' + post.uuid);
     }
 
     post.raw = lines.join('\n');

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "eslint": "node_modules/.bin/eslint .",
     "jscs": "node_modules/.bin/jscs .",
     "test": "node_modules/.bin/mocha tests/index.js",
-    "test-cover": "node_modules/.bin/istanbul cover --print both node_modules/.bin/_mocha -- tests/index.js"
+    "test-cover": "node_modules/.bin/istanbul cover --print both node_modules/mocha/bin/_mocha -- tests/index.js"
   },
   "directories": {
     "lib": "./lib"

--- a/tests/index.js
+++ b/tests/index.js
@@ -8,9 +8,9 @@ const hexo = new Hexo(__dirname, {
   silent: true
 });
 
-hexo.on('new', HexoUuid);
+hexo.on('new', HexoUuid.newPost);
 
-describe('Post With User Pre-defined UUID Attribute', () => {
+describe('Post With User Pre-defined UUID Attribute on new post', () => {
 
   let post = {
     path: false,
@@ -32,7 +32,7 @@ tags:
 
 });
 
-describe('Post Without User Pre-defined UUID Attribute', () => {
+describe('Post Without User Pre-defined UUID Attribute on new post', () => {
 
   let post = {
     path: './tmp/test.md',
@@ -48,6 +48,81 @@ tags:
 
   it('Post should have uuid', () => {
     let uuidPresence = /uuid: .{36}\n/.test(post.content);
+    uuidPresence.should.equal(true);
+  });
+
+});
+
+hexo.extend.filter.register('before_post_render', HexoUuid.before_renderPost);
+
+describe('Post With User Pre-defined UUID Attribute before render', () => {
+
+  let post = {
+    layout:'post',
+    uuid: '7848d740-fd9a-11e7-ba72-ab02344a9ad8',
+    full_source: './tmp/test.md',
+    raw: `'---
+uuid: 7848d740-fd9a-11e7-ba72-ab02344a9ad8
+title: I love Hexo!
+date: 2016-05-20 16:20
+tags:
+---
+test
+    `
+  };
+
+  hexo.extend.filter.exec('before_post_render', post);
+
+  it('Post should have uuid', () => {
+    let uuidPresence = /uuid: .{36}\n/.test(post.raw);
+    uuidPresence.should.equal(true);
+  });
+
+});
+
+describe('Post Without User Pre-defined UUID Attribute before render', () => {
+
+  let post = {
+    layout:'post',
+    full_source: './tmp/test.md',
+    raw: `'---
+title: I love Hexo!
+date: 2016-05-20 16:20
+tags:
+---
+test
+    `
+  };
+
+  hexo.extend.filter.exec('before_post_render', post);
+
+  it('Post should have uuid', () => {
+    let uuidPresence = /uuid: .{36}\n/.test(post.raw);
+    uuidPresence.should.equal(true);
+  });
+
+});
+
+describe('Post With User Pre-defined UUID Attribute but blank before render', () => {
+
+  let post = {
+    uuid: '',
+    layout:'post',
+    full_source: './tmp/test.md',
+    raw: `'---
+uuid:
+title: I love Hexo!
+date: 2016-05-20 16:20
+tags:
+---
+test
+    `
+  };
+
+  hexo.extend.filter.exec('before_post_render', post);
+
+  it('Post should have uuid', () => {
+    let uuidPresence = /uuid: .{36}\n/.test(post.raw);
     uuidPresence.should.equal(true);
   });
 


### PR DESCRIPTION
每寫一篇文章都要輸入 hexo new xxx 的指令，對一個習慣直接開 .md 檔寫文章的人來說感覺就是多了一道程序，希望能自動在未添加 uuid 屬性的文章自動增加 uuid 屬性再生成靜態檔案！

所以就寫了不到 20 行的 code 來實現這個功能

----
原本有測試過 eslint 過了沒測試 jscs ，就沒發現檔案尾端要留空行，十分抱歉